### PR TITLE
Use native json module if available

### DIFF
--- a/restless/http.py
+++ b/restless/http.py
@@ -1,6 +1,12 @@
 from django import http
-from django.utils import simplejson as json
 from django.core.serializers.json import DjangoJSONEncoder
+
+try:
+    # json module from python > 2.6
+    import json
+except ImportError:
+    # use packaged django version of simplejson
+    from django.utils import simplejson as json
 
 
 __all__ = ['JSONResponse', 'JSONErrorResponse',


### PR DESCRIPTION
I was running into some issues with newer versions of simplejson and django as described here:
https://docs.djangoproject.com/en/dev/releases/1.5/#simplejson-incompatibilities
and here:
https://docs.djangoproject.com/en/dev/releases/1.5/#django-utils-simplejson

The problem arises when there is another version of simplejson (>2.1) installed next to the usual django.utils.simplejson module.

Anyway, just a small patch to follow the recommendations of the django devs to use native json module instead of django.utils.simplejson.
