### PR TITLE
HttpResponse objects via authenticate() will now stop view execution

### DIFF
--- a/restless/views.py
+++ b/restless/views.py
@@ -91,7 +91,9 @@ class Endpoint(View):
 
         try:
             self._parse_body(request)
-            self._process_authenticate(request)
+            authentication_required = self._process_authenticate(request)
+            if authentication_required:
+                return authentication_required
 
             response = super(Endpoint, self).dispatch(request, *args, **kwargs)
         except HttpError as err:


### PR DESCRIPTION
Prior to this change, `authenticate()` methods defined on an `Endpoint` which returned `HttpResponse` objects were ignored. The logic did a good job checking for `None` and invalid objects, but if a valid object was returned ... it wasn't enforced.

Now the response from `authenticate()` is stored and if it is not `None` (which means it's a valid response object) execution is stopped and that response is sent directly to the user.
