### PR TITLE
URL fix for pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     author_email='senko.rasic@goodcode.io',
     description='A RESTful framework for Django',
     license='MIT',
-    url='github.com/dobarkod/django-restless',
+    url='https://github.com/dobarkod/django-restless',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Web Environment",


### PR DESCRIPTION
See https://pypi.python.org/pypi/DjangoRestless
