### PR TITLE
Removing request content type configuration that cleans request data

### DIFF
--- a/restless/views.py
+++ b/restless/views.py
@@ -92,7 +92,6 @@ class Endpoint(View):
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
-        request.content_type = request.META.get('CONTENT_TYPE', 'text/plain')
         request.params = dict((k, v) for (k, v) in request.GET.items())
         request.data = None
         request.raw_data = request.body


### PR DESCRIPTION
After the execution of dispatch, the following code:
request.content_type = request.META.get('CONTENT_TYPE', 'text/plain')
The request contents (POST, body) are cleaned if the post is a multipart/form-data