### PR TITLE
PATCH method, flake8, star imports, etc.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ class CoverageCommand(BaseCommand):
 
 setup(
     name='DjangoRestless',
-    version='0.0.10',
+    version='0.0.11',
     author='Senko Rasic',
     author_email='senko.rasic@goodcode.io',
     description='A RESTful framework for Django',

--- a/testproject/testapp/forms.py
+++ b/testproject/testapp/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from .models import *
+from .models import Author
 
 __all__ = ['AuthorForm']
 

--- a/testproject/testapp/urls.py
+++ b/testproject/testapp/urls.py
@@ -6,7 +6,12 @@ except ImportError:
     def patterns(prefix, *args):
         return args
 
-from .views import *
+from .views import (AuthorList, AuthorDetail, FailsIntentionally, TestLogin,
+                    TestBasicAuth, TestCustomAuthMethod, EchoView,
+                    ErrorRaisingView, PublisherAutoList,
+                    ReadOnlyPublisherAutoList, PublisherAutoDetail,
+                    PublisherAction, BookDetail, WildcardHandler)
+
 
 urlpatterns = patterns('',
     url(r'^authors/$', AuthorList.as_view(),

--- a/testproject/testapp/views.py
+++ b/testproject/testapp/views.py
@@ -4,17 +4,19 @@ from restless.views import Endpoint
 from restless.models import serialize
 from restless.http import Http201, Http403, Http404, Http400, HttpError
 from restless.auth import (AuthenticateEndpoint, BasicHttpAuthMixin,
-    login_required)
+                           login_required)
 
 from restless.modelviews import ListEndpoint, DetailEndpoint, ActionEndpoint
 
-from .models import *
-from .forms import *
+from .models import Publisher, Author, Book
+from .forms import AuthorForm
 
-__all__ = ['AuthorList', 'AuthorDetail', 'FailsIntentionally', 'TestLogin',
+__all__ = [
+    'AuthorList', 'AuthorDetail', 'FailsIntentionally', 'TestLogin',
     'TestBasicAuth', 'WildcardHandler', 'EchoView', 'ErrorRaisingView',
     'PublisherAutoList', 'PublisherAutoDetail', 'ReadOnlyPublisherAutoList',
-    'PublisherAction', 'BookDetail', 'TestCustomAuthMethod']
+    'PublisherAction', 'BookDetail', 'TestCustomAuthMethod'
+]
 
 
 class AuthorList(Endpoint):
@@ -27,8 +29,7 @@ class AuthorList(Endpoint):
             author = form.save()
             return Http201(serialize(author))
         else:
-            return Http400(reason='invalid author data',
-                details=form.errors)
+            return Http400(reason='invalid author data', details=form.errors)
 
 
 class AuthorDetail(Endpoint):
@@ -56,8 +57,7 @@ class AuthorDetail(Endpoint):
             author = form.save()
             return serialize(author)
         else:
-            return Http400(reason='invalid author data',
-                details=form.errors)
+            return Http400(reason='invalid author data', details=form.errors)
 
 
 class FailsIntentionally(Endpoint):

--- a/testproject/testproject/wsgi.py
+++ b/testproject/testproject/wsgi.py
@@ -20,7 +20,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testproject.settings")
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
-from django.core.wsgi import get_wsgi_application
+from django.core.wsgi import get_wsgi_application  # NOQA
 application = get_wsgi_application()
 
 # Apply WSGI middleware here.


### PR DESCRIPTION
This PR:

- Adds a PATCH method on modelviews.DetailEndpoint;
- Gets rid of star imports (`from <module> import *`);
- Fixes indentation on parameters and arguments so the code passes on flake8;
- Fixes the URL patterns declarations on *testproject*.

And I'm afraid it breaks compatibility with older versions of Django, since it's using "new style" URL patterns...